### PR TITLE
fixing ctl and mu

### DIFF
--- a/src/ltsmin-lib/ltsmin-tl.c
+++ b/src/ltsmin-lib/ltsmin-tl.c
@@ -467,7 +467,10 @@ pred_tree_walk(ltsmin_expr_t e, ltsmin_parse_env_t env, lts_type_t lts_type)
                         type_check_require_format(lts_type, right, formats, 2, e->arg1, env, "enum, chunk");
                         e->annotation->chunk_type = type_check_get_type(lts_type, LTSMIN_TYPE_BOOL, e, env);;
                         break;
-                    } else break;
+                    } else {
+		        e->annotation->chunk_type = type_check_get_type(lts_type, LTSMIN_TYPE_BOOL, e, env);
+			break;
+		    }
                 }
                 default: {
                     LTSminLogExpr (error, "Unhandled predicate expression: ", e, env);

--- a/src/pins2lts-sym/pins2lts-sym.c
+++ b/src/pins2lts-sym/pins2lts-sym.c
@@ -3840,7 +3840,7 @@ mu_compute(ltsmin_expr_t mu_expr, vset_t visited, vset_t* mu_var, array_manager_
         /* Currently MU_EQ works only in the context of an SVAR/INTEGER pair */
         if (mu_expr->arg1->token != MU_SVAR)
             Abort("Expecting == with state variable on the left side!\n");
-        if (mu_expr->arg1->token != MU_NUM)
+        if (mu_expr->arg2->token != MU_NUM)
             Abort("Expecting == with int on the right side!\n");
         result = get_svar_eq_int_set(mu_expr->arg1->idx, mu_expr->arg2->idx, visited);
     } break;

--- a/src/pins2lts-sym/pins2lts-sym.c
+++ b/src/pins2lts-sym/pins2lts-sym.c
@@ -3838,9 +3838,9 @@ mu_compute(ltsmin_expr_t mu_expr, vset_t visited, vset_t* mu_var, array_manager_
         return vset_create(domain, -1, NULL);
     case MU_EQ: { // svar == int
         /* Currently MU_EQ works only in the context of an SVAR/INTEGER pair */
-        if (!mu_expr->arg1->token == MU_SVAR)
+        if (mu_expr->arg1->token != MU_SVAR)
             Abort("Expecting == with state variable on the left side!\n");
-        if (!mu_expr->arg1->token == MU_NUM)
+        if (mu_expr->arg1->token != MU_NUM)
             Abort("Expecting == with int on the right side!\n");
         result = get_svar_eq_int_set(mu_expr->arg1->idx, mu_expr->arg2->idx, visited);
     } break;


### PR DESCRIPTION
Some small fixes, one suppresses a warning (it was indeed wrong), the other is needed to parse equalities between variables. More fixes follow, as part of further development on CTL.
